### PR TITLE
More BitBucket - commit history

### DIFF
--- a/lib/bitbucket/BitBucketClient.js
+++ b/lib/bitbucket/BitBucketClient.js
@@ -24,10 +24,10 @@ function BitBucketClient(options) {
         })
     }
 
-    this.getContent = function(user, repo, path, next) {
+    this.getContent = function(username, reponame, path, next) {
         bitbucket.getRepository({ 
-            owner: user,
-            slug: repo
+            owner: username,
+            slug: reponame
         }, function(err, repository) {
             repository.sources('/' + path).raw(function(err, res) {
                 next(extractError(err), res.raw);
@@ -35,8 +35,8 @@ function BitBucketClient(options) {
         })
     }
 
-    this.getBytes = function(user, repo, path, next) {  
-        this.getContent(user, repo, path, function(err, content) {
+    this.getBytes = function(username, reponame, path, next) {
+        this.getContent(username, reponame, path, function(err, content) {
             if (err && err.message == 'Not Found') return next();
             if (err) return next(err);
             if (content == 'Not Found' || content == 'error') return next();
@@ -44,18 +44,16 @@ function BitBucketClient(options) {
         })
     } 
 
-    this.getCommits = function(user, repo, next) {
-        next(null, []);
-        // TODO not sure this API works?
-        // bitbucket.getRepository({ 
-        //     owner: user,
-        //     slug: repo
-        // }, function(err, repository) {
-        //     repository.changesets().get(50, '0', function(err, commits) {
-        //         logger.debug('BB getCommits', err, commits);
-        //         next(extractError(err), commits);
-        //     });
-        // })
+    this.getCommits = function(username, reponame, next) {
+        var repo = { 
+            owner: username,
+            slug: reponame
+        };
+        bitbucket.getRepository(repo, function(err, repository) {
+            repository.changesets().get(5, null, function(err, commits) {
+                next(extractError(err), _.chain(commits.changesets).extend(repo).value() );
+            });
+        })
     }
 
     this.filterClause = function() {
@@ -70,6 +68,17 @@ function BitBucketClient(options) {
         mapped.private   = mapped.is_private;
         mapped.html_url  = mapped.resource_uri.replace('/1.0/repositories', 'https://bitbucket.org');
         return mapped;
+    }
+
+    this.toActivity = function(commit) {
+        var activity = {};
+        activity.name = commit.author;
+        activity.email = commit.raw_author;
+        activity.date = commit.timestamp;
+        activity.id = commit.node;
+        activity.message = commit.message;
+        activity.html_url = 'https://bitbucket.org/' + commit.owner + '/' + commit.slug + '/commits/' + commit.node;
+        return activity;
     }
 
     function extractError(err) {

--- a/lib/github/GitHubClient.js
+++ b/lib/github/GitHubClient.js
@@ -65,6 +65,16 @@ function GitHubClient(options) {
         return _.pick(repo, 'id', 'name', 'description', 'full_name', 'html_url', 'private', 'language');
     }
 
+    this.toActivity = function(entry) {
+        return _.chain(entry.commit.author)
+                .extend(entry.author)
+                .extend({ date: new Date(entry.commit.author.date) })
+                .extend({ message: entry.commit.message })
+                .pick('name', 'email', 'date', 'login', 'id', 'message', 'avatar_url', 'html_url')
+                .value();
+    }
+
+
     function extractError(err) {
         return err && json.isJson(err.message) ? JSON.parse(err.message) : err;
     }    

--- a/lib/survey/tasks/getMostRecentActivity.js
+++ b/lib/survey/tasks/getMostRecentActivity.js
@@ -10,7 +10,7 @@ function getMostRecentActivity(organisation, next) {
     var names = {};
 
     var q = async.queue(function(task, callback) {
-        logger.info("Fetching %s commits", task.repo.full_name);
+        logger.info("Fetching %s %s commits", task.repo.providerKey, task.repo.full_name);
 
         organisation.provider.getCommits(task.organisation.name, task.repo.name, function(err, commits) {
             if (err) return handleError(task.repo, err, callback);
@@ -26,16 +26,7 @@ function getMostRecentActivity(organisation, next) {
     }) 
 
     function getActivity(commits) {
-        return _.chain(commits).map(toActivity).unique(byAuthor).sort(byCommitDate).reverse().slice(0, 5).value();        
-    }    
-
-    function toActivity(entry) {
-        return _.chain(entry.commit.author)
-                .extend(entry.author)
-                .extend({ date: new Date(entry.commit.author.date) })
-                .extend({ message: entry.commit.message })
-                .pick('name', 'email', 'date', 'login', 'id', 'message', 'avatar_url', 'html_url')
-                .value();
+        return _.chain(commits).map(organisation.provider.toActivity).unique(byAuthor).sort(byCommitDate).reverse().slice(0, 5).value();
     }
 
     function byAuthor(author) {
@@ -50,5 +41,5 @@ function getMostRecentActivity(organisation, next) {
         repo.error = err;
         logger.error('Error fetching commits for %s : %s', repo.name, err.message);
         next();
-    }   
+    }
 }

--- a/lib/survey/tasks/getRepoCopJson.js
+++ b/lib/survey/tasks/getRepoCopJson.js
@@ -8,7 +8,7 @@ module.exports = getRepoCopJson;
 function getRepoCopJson(organisation, next) {
 
     var q = async.queue(function(task, callback) {
-        logger.info("Fetching %s metadata", task.repo.full_name);
+        logger.info("Fetching %s %s metadata", task.repo.providerKey, task.repo.full_name);
 
         organisation.provider.getBytes(task.organisation.name, task.repo.name, 'repocop.json', function(err, buffer) {  
             if (err) return captureError(task.repo, err, callback);

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "recluster": "^0.3.6",
     "request": "^2.34.0",
     "moment": "^2.5.1",
-    "bitbucket-api": "0.0.6"
+    "bitbucket-api": "git+https://bitbucket.org/MailOnline/node-bitbucket-api.git"
   }
 }


### PR DESCRIPTION
OK, so now supports the commit & last activity info. No gravatar icons or links though.

One package.json warning - this depends on a fork of the node-bitbucket-api to remove a mandatory "commit hash/node" property. The maintainer of that hasn't been very active, so I'm not sure if he'll merge my changes or not. We'll see.
